### PR TITLE
Adjust the way that progress ticks to be ignored by default 

### DIFF
--- a/R/bm-placebo.R
+++ b/R/bm-placebo.R
@@ -4,7 +4,7 @@
 #' * `duration` the duration for the benchmark to take
 #'
 placebo <- Benchmark("placebo",
-  setup = function(duration = 1, grid = TRUE, ...) {
+  setup = function(duration = 0.01, grid = TRUE, ...) {
     BenchEnvironment(placebo_func = function() {Sys.sleep(duration)})
   },
   before_each = TRUE,

--- a/man/run_one.Rd
+++ b/man/run_one.Rd
@@ -10,7 +10,7 @@ run_one(
   n_iter = 1,
   dry_run = FALSE,
   profiling = FALSE,
-  progress_bar,
+  progress_bar = NULL,
   read_only = FALSE,
   test_packages = NULL
 )

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1,3 +1,5 @@
+wipe_results <- function() unlink(test_path("results/placebo"))
+
 test_that("run_iteration", {
   b <- Benchmark("test")
   out <- run_iteration(b, ctx = new.env())
@@ -22,4 +24,10 @@ test_that("run_bm", {
   expect_identical(nrow(out$result), 3L)
 
   expect_error(run_bm(b, param1 = "b"), "isTRUE(result) is not TRUE", fixed = TRUE)
+})
+
+
+test_that("run_one", {
+  run_one(placebo)
+  wipe_results()
 })


### PR DESCRIPTION
(e.g. `run_one()`) and update how progress is polled