### PR TITLE
Ensure that arguments aren't silently eaten + ignored

### DIFF
--- a/R/bm-dataset-taxi-parquet.R
+++ b/R/bm-dataset-taxi-parquet.R
@@ -5,8 +5,7 @@
 #'
 #' @export
 dataset_taxi_parquet <- Benchmark("dataset_taxi_parquet",
-  setup = function(query = names(dataset_taxi_parquet$cases),
-                   ...) {
+  setup = function(query = names(dataset_taxi_parquet$cases)) {
     library("dplyr")
     dataset <- ensure_dataset("taxi_parquet")
     query <- dataset_taxi_parquet$cases[[match.arg(query)]]

--- a/R/bm-placebo.R
+++ b/R/bm-placebo.R
@@ -4,7 +4,7 @@
 #' * `duration` the duration for the benchmark to take
 #'
 placebo <- Benchmark("placebo",
-  setup = function(duration = 0.01, grid = TRUE, ...) {
+  setup = function(duration = 0.01, grid = TRUE) {
     BenchEnvironment(placebo_func = function() {Sys.sleep(duration)})
   },
   before_each = TRUE,

--- a/R/bm-read-csv.R
+++ b/R/bm-read-csv.R
@@ -13,8 +13,7 @@ read_csv <- Benchmark(
   setup = function(source = names(known_sources),
                    reader = c("arrow", "data.table", "vroom", "readr"),
                    compression = c("uncompressed", "gzip"),
-                   output = c("arrow_table", "data_frame"),
-                   ...) {
+                   output = c("arrow_table", "data_frame")) {
     reader <- match.arg(reader)
     compression <- match.arg(compression)
     output <- match.arg(output)
@@ -45,8 +44,7 @@ read_csv <- Benchmark(
       input_file = input_file,
       result_dim = result_dim,
       as_data_frame = output == "data_frame",
-      delim = delim,
-      ...
+      delim = delim
     )
   },
   before_each = {

--- a/R/bm-read-file.R
+++ b/R/bm-read-file.R
@@ -12,8 +12,7 @@ read_file <- Benchmark("read_file",
                    # TODO: break out feather_v1 and feather_v2, feather_v2 only in >= 0.17
                    format = c("parquet", "feather", "fst"),
                    compression = c("uncompressed", "snappy", "zstd"),
-                   output = c("arrow_table", "data_frame"),
-                   ...) {
+                   output = c("arrow_table", "data_frame")) {
     format <- match.arg(format)
     compression <- match.arg(compression)
     output <- match.arg(output)

--- a/R/bm-write-file.R
+++ b/R/bm-write-file.R
@@ -11,8 +11,7 @@ write_file <- Benchmark("write_file",
   setup = function(source = names(known_sources),
                    format = c("parquet", "feather", "fst"),
                    compression = c("uncompressed", "snappy", "zstd"),
-                   input = c("arrow_table", "data_frame"),
-                   ...) {
+                   input = c("arrow_table", "data_frame")) {
     source <- ensure_source(source)
     df <- read_source(source, as_data_frame = match.arg(input) == "data_frame")
     format <- match.arg(format)
@@ -39,7 +38,8 @@ write_file <- Benchmark("write_file",
     unlink(result_file)
   },
   valid_params = function(params) {
-    drop <- params$format != "parquet" & params$compression == "snappy"
+    drop <- params$format != "parquet" & params$compression == "snappy" |
+      params$format == "fst" & params$input == "arrow_table"
     params[!drop,]
   },
   packages_used = function(params) {

--- a/R/ensure-lib.R
+++ b/R/ensure-lib.R
@@ -81,6 +81,7 @@ ensure_lib <- function(lib = NULL, test_packages = unlist(strsplit(packageDescri
     # git hash? build from source
     # TODO: use remotes package for github ref management
     # For mac, need to do what crossbow and arrow-r-nightly do to use autobrew and pin commit
+    stop("The lib_path is not a known value: ", lib)
   }
   lib_dir_path
 }

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -31,3 +31,18 @@ test_that("run_one", {
   run_one(placebo)
   wipe_results()
 })
+
+test_that("Argument validation", {
+  expect_message(
+    run_one(placebo, not_an_arg = 1, cpu_count = 1),
+    "Error.*unused argument.*not_an_arg"
+  )
+
+  expect_message(
+    run_one(placebo, cpu_count = 1),
+    NA
+  )
+  wipe_results()
+})
+
+wipe_results()


### PR DESCRIPTION
This has bitten me a few times (and a few others) With this change, passing unknown arguments to a benchmark will fail. I didn't have to change much about how things are run, mostly removed the `...` from the `setup()` step of each (and had to remove our system/global level ones from the list before passing it to `setup()`